### PR TITLE
Fjerner endepunkt /finnSamhandlerResponse

### DIFF
--- a/src/main/kotlin/no/nav/pensjon_samhandler_proxy/SamhandlerController.kt
+++ b/src/main/kotlin/no/nav/pensjon_samhandler_proxy/SamhandlerController.kt
@@ -29,18 +29,6 @@ class SamhandlerController(
         )
     }
 
-    @PostMapping("/finnSamhandlerResponse")
-    fun finnSamhandlerResponse(@RequestBody soek: Soek): FinnSamhandlerResponse {
-        return FinnSamhandlerResponse(
-            samhandlerService.finnSamhandler(
-                soek.navn?.takeIf { it.isNotBlank() },
-                soek.idType?.takeIf { it.isNotBlank() },
-                soek.offentligId?.takeIf { it.isNotBlank() },
-                soek.samhandlerType?.takeIf { it.isNotBlank() },
-            )
-        )
-    }
-
     @GetMapping("/ping")
     fun ping() = "PONG"
 


### PR DESCRIPTION
Må merges etter at alle konsumenter har begynt å bruke `/finnSamhandler` igjen